### PR TITLE
test, chore: unit test configuration, eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,9 @@
       ],
       "rules": {
         "semi": "error",
-        "quotes": ["error", "single"]
+        "quotes": ["error", "single"],
+        "comma-dangle": ["error", "always-multiline"],
+        "object-curly-spacing": ["error", "always"]
       }
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@angular/platform-browser": "~13.3.0",
         "@angular/platform-browser-dynamic": "~13.3.0",
         "@angular/router": "~13.3.0",
+        "jwt-decode": "^3.1.2",
         "primeflex": "^3.1.3",
         "primeicons": "^5.0.0",
         "primeng": "^13.3.3",
@@ -42,6 +43,7 @@
         "karma-chrome-launcher": "~3.1.0",
         "karma-coverage": "~2.1.0",
         "karma-firefox-launcher": "~2.1.2",
+        "karma-jasmine": "~4.0.0",
         "karma-jasmine-html-reporter": "~1.7.0",
         "typescript": "~4.6.2"
       }
@@ -8988,6 +8990,11 @@
       "engines": [
         "node >= 0.2.0"
       ]
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/karma": {
       "version": "6.3.19",
@@ -20436,6 +20443,11 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "karma": {
       "version": "6.3.19",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@angular/platform-browser": "~13.3.0",
     "@angular/platform-browser-dynamic": "~13.3.0",
     "@angular/router": "~13.3.0",
+    "jwt-decode": "^3.1.2",
     "primeflex": "^3.1.3",
     "primeicons": "^5.0.0",
     "primeng": "^13.3.3",
@@ -43,8 +44,8 @@
     "jasmine-core": "~4.0.0",
     "karma": "~6.3.0",
     "karma-chrome-launcher": "~3.1.0",
-    "karma-firefox-launcher": "~2.1.2",
     "karma-coverage": "~2.1.0",
+    "karma-firefox-launcher": "~2.1.2",
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "~1.7.0",
     "typescript": "~4.6.2"

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,6 +10,6 @@ const routes: Routes = [
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
 export class AppRoutingModule { }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,15 +1,36 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { MessageService } from 'primeng/api';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
+import { ToolbarModule } from 'primeng/toolbar';
 import { AppComponent } from './app.component';
+import { AuthService } from './service/auth/auth.service';
 
 describe('AppComponent', () => {
+  let authServiceStub: Partial<AuthService>;
+  let messageServiceStub: Partial<MessageService>;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule
+        RouterTestingModule,
+        ToolbarModule,
+        ToastModule,
+        ButtonModule,
       ],
       declarations: [
-        AppComponent
+        AppComponent,
+      ],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: authServiceStub,
+        },
+        {
+          provide: MessageService,
+          useValue: messageServiceStub,
+        },
       ],
     }).compileComponents();
   });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,7 +17,7 @@ import { PasswordModule } from 'primeng/password';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { LoginFormComponent } from './login-form/login-form.component';
-import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RegisterFormComponent } from './register-form/register-form.component';
 
 @NgModule({
@@ -46,6 +46,6 @@ import { RegisterFormComponent } from './register-form/register-form.component';
     FormsModule,
   ],
   providers: [],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
 export class AppModule { }

--- a/src/app/login-form/login-form.component.html
+++ b/src/app/login-form/login-form.component.html
@@ -4,7 +4,7 @@
       <span class="p-inputgroup-addon">
         <i class="pi pi-envelope"></i>
       </span>
-      <input type="text" pInputText formControlName="email" placeholder="Email">         
+      <input type="text" pInputText formControlName="email" placeholder="Email">
     </div>
     <div class="p-inputgroup col-12">
       <span class="p-inputgroup-addon">

--- a/src/app/login-form/login-form.component.spec.ts
+++ b/src/app/login-form/login-form.component.spec.ts
@@ -1,14 +1,38 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { ButtonModule } from 'primeng/button';
+import { CheckboxModule } from 'primeng/checkbox';
+import { PasswordModule } from 'primeng/password';
+import { AuthService } from '../service/auth/auth.service';
 
 import { LoginFormComponent } from './login-form.component';
 
 describe('LoginFormComponent', () => {
   let component: LoginFormComponent;
   let fixture: ComponentFixture<LoginFormComponent>;
+  let authServiceStub: Partial<AuthService>;
+  let messageServiceStub: Partial<MessageService>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ LoginFormComponent ]
+      declarations: [ LoginFormComponent ],
+      imports: [
+        ReactiveFormsModule,
+        PasswordModule,
+        CheckboxModule,
+        ButtonModule,
+      ],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: authServiceStub,
+        },
+        {
+          provide: MessageService,
+          useValue: messageServiceStub,
+        },
+      ],
     })
     .compileComponents();
   });

--- a/src/app/register-form/register-form.component.spec.ts
+++ b/src/app/register-form/register-form.component.spec.ts
@@ -1,14 +1,40 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { CalendarModule } from 'primeng/calendar';
+import { CheckboxModule } from 'primeng/checkbox';
+import { PasswordModule } from 'primeng/password';
+import { AuthService } from '../service/auth/auth.service';
 
 import { RegisterFormComponent } from './register-form.component';
 
 describe('RegisterFormComponent', () => {
   let component: RegisterFormComponent;
   let fixture: ComponentFixture<RegisterFormComponent>;
+  let authServiceStub: Partial<AuthService>;
+  let messageServiceStub: Partial<MessageService>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ RegisterFormComponent ]
+      declarations: [
+        RegisterFormComponent,
+      ],
+      imports: [
+        ReactiveFormsModule,
+        PasswordModule,
+        CheckboxModule,
+        CalendarModule,
+      ],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: authServiceStub,
+        },
+        {
+          provide: MessageService,
+          useValue: messageServiceStub,
+        },
+      ],
     })
     .compileComponents();
   });

--- a/src/app/service/auth/auth.service.spec.ts
+++ b/src/app/service/auth/auth.service.spec.ts
@@ -1,16 +1,37 @@
+// import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
   let service: AuthService;
+  // let httpClient: HttpClient;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+      ],
+    });
+
+    // httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
     service = TestBed.inject(AuthService);
   });
 
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
   it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should make login request', () => {
     expect(service).toBeTruthy();
   });
 });

--- a/src/app/service/change-theme/change-theme.service.spec.ts
+++ b/src/app/service/change-theme/change-theme.service.spec.ts
@@ -18,13 +18,13 @@ describe('ChangeThemeService', () => {
   it('should change theme', () => {
     service.switchTheme();
 
-    expect(service['_isLightTheme']).toBeTrue();
+    expect(service['_isLightTheme']).toBeFalse();
   });
 
   it('should change theme back', () => {
     service.switchTheme();
     service.switchTheme();
 
-    expect(service['_isLightTheme']).toBeFalse();
+    expect(service['_isLightTheme']).toBeTrue();
   });
 });

--- a/src/app/service/change-theme/change-theme.service.ts
+++ b/src/app/service/change-theme/change-theme.service.ts
@@ -2,7 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import { Inject, Injectable } from '@angular/core';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ChangeThemeService {
   private _isLightTheme = true;
@@ -13,6 +13,7 @@ export class ChangeThemeService {
   constructor(
     @Inject(DOCUMENT) private document: Document,
   ) {
+    this.getTheme();
     this.setTheme();
   }
 
@@ -21,7 +22,14 @@ export class ChangeThemeService {
     this.setTheme();
   }
 
-  setTheme() {
+  getTheme(): void {
+    if (localStorage.getItem('theme') === 'dark') {
+      this._isLightTheme = false;
+    }
+  }
+
+  setTheme(): void {
+    localStorage.setItem('theme', this._isLightTheme ? 'light' : 'dark');
     const themeLink = this.document.getElementById('app-theme') as HTMLLinkElement;
     if (themeLink) {
       themeLink.href = `lara-${this._isLightTheme ? 'light' : 'dark'}.css`;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,3 @@
 export const environment = {
-  production: true
+  production: true,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,7 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
 };
 
 /*

--- a/src/test.ts
+++ b/src/test.ts
@@ -4,7 +4,7 @@ import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
+  platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
 
 declare const require: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "strictPropertyInitialization": false,
+    "strictNullChecks": false,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
- Added eslint rules
- Disabled strict null rule
- Provided configuration for all test files (all tests passes now)
- Added missing `jwt-decode` package
- Theme preference is now stored in local storage